### PR TITLE
normalize urls before passing them to Chromium

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -650,6 +650,12 @@
 										"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
 										"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
 										"dev": true
+								},
+								"normalize-url": {
+										"version": "4.5.0",
+										"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+										"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+										"dev": true
 								}
 						}
 				},
@@ -2375,10 +2381,9 @@
 						"dev": true
 				},
 				"normalize-url": {
-						"version": "4.5.0",
-						"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-						"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-						"dev": true
+						"version": "5.3.0",
+						"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.3.0.tgz",
+						"integrity": "sha512-9/nOVLYYe/dO/eJeQUNaGUF4m4Z5E7cb9oNTKabH+bNf19mqj60txTcveQxL0GlcWLXCxkOu2/LwL8oW0idIDA=="
 				},
 				"on-finished": {
 						"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"sirv": "^1.0.7"
 	},
 	"dependencies": {
+		"normalize-url": "^5.3.0",
 		"puppeteer": "^5.5.0"
 	},
 	"eslintConfig": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 /* global document */
 const puppeteer = require('puppeteer')
+const normalizeUrl = require('normalize-url')
 
 function InvalidUrlError({url, statusCode, statusText}) {
 	this.name = 'InvalidUrlError'
@@ -20,6 +21,7 @@ module.exports = async (url, {waitUntil = 'networkidle0', origins = 'exclude'} =
 	// Create a new page and navigate to it
 	const page = await browser.newPage()
 	await page.coverage.startCSSCoverage()
+	url = normalizeUrl(url, {stripWWW: false})
 	const response = await page.goto(url, {waitUntil})
 
 	// Make sure that we only try to extract CSS from valid pages.


### PR DESCRIPTION
This fixes an issue where the package would throw an error for url's like `tv.apple.com`, as [reported by @mehulkar on Twitter](https://twitter.com/mehulkar/status/1329840882703605760)