### PR TITLE
Set custom User-Agent string for Puppeteer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,10 @@ module.exports = async (url, {waitUntil = 'networkidle0', origins = 'exclude'} =
 
 	// Create a new page and navigate to it
 	const page = await browser.newPage()
+
+	// Set an explicit UserAgent, because the default UserAgent string includes something like
+	// `HeadlessChrome/88.0.4298.0` and some websites/CDN's block that with a HTTP 403
+	await page.setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.16; rv:85.0) Gecko/20100101 Firefox/85.0')
 	await page.coverage.startCSSCoverage()
 	url = normalizeUrl(url, {stripWWW: false})
 	const response = await page.goto(url, {waitUntil})


### PR DESCRIPTION
 as workaround for websites that block Puppeteer when `HeadlessChrome` is present in the UA string.

Closes #41 